### PR TITLE
FIX: Implement missing AbstractEconomy methods so there is no undefined behaviour

### DIFF
--- a/src/main/java/com/mikey1201/providers/EconomyProvider.java
+++ b/src/main/java/com/mikey1201/providers/EconomyProvider.java
@@ -40,9 +40,7 @@ public class EconomyProvider extends AbstractEconomy {
 
     @Override
     public boolean hasAccount(OfflinePlayer player) {
-        if (player == null || player.getUniqueId() == null) {
-            return false;
-        }
+        if (player == null) return false;
         return database.hasAccount(player.getUniqueId());
     }
 
@@ -79,6 +77,16 @@ public class EconomyProvider extends AbstractEconomy {
     }
 
     @Override
+    public double getBalance(OfflinePlayer player, String world) {
+        if (!hasAccount(player)) {
+            return 0.0;
+        }
+        return database.getBalance(player.getUniqueId());
+    }
+
+    @Override
+    public EconomyResponse withdrawPlayer(OfflinePlayer p, String w, double a) { return withdrawPlayer(p, a); }
+    @Override
     public EconomyResponse withdrawPlayer(String s, String s1, double v) { return withdrawPlayer(s, v); }
     @Override
     public EconomyResponse withdrawPlayer(String playerName, double amount) {
@@ -103,6 +111,8 @@ public class EconomyProvider extends AbstractEconomy {
         return new EconomyResponse(amount, newBalance, EconomyResponse.ResponseType.SUCCESS, null);
     }
 
+    @Override
+    public EconomyResponse depositPlayer(OfflinePlayer p, String w, double a) { return depositPlayer(p, a); }
     @Override
     public EconomyResponse depositPlayer(String s, String s1, double v) { return depositPlayer(s, v); }
     @Override
@@ -137,7 +147,7 @@ public class EconomyProvider extends AbstractEconomy {
 
     @Override
     public boolean createPlayerAccount(OfflinePlayer player) {
-        if (player == null || player.getUniqueId() == null) return false;
+        if (player == null) return false;
         if (hasAccount(player)) return false;
 
         database.createPlayerAccount(player);


### PR DESCRIPTION
I've found this plugin quite nice for my towny server. But after enabling it, turned out that deposit/withdraw is bugged.

The reason of these bugs can be seen in the stacktrace
Towny.deposit(OfflinePlayer, worldName, amount) -> AbstractEconomy.deposit(OfflinePlayer, worldName, amount) -> AbstractEconomy.deposit(OfflinePlayer.getName(), worldName, amount) -> DiamondEconomy.deposit(playerName, worldName, amount) -> DiamondEconomy.deposit(playerName, amount)

We've lost the OfflinePlayer object.

The solution is simple => we're implementing these methods, so there's no calls to the parent class and we're forwarding OfflinePlayer object instead of its name into the deposit logic.